### PR TITLE
Changed simple to elegant on homepage intro

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -8,5 +8,5 @@ type = "index"
   <h1>Cloud Native Infrastructure.</h1>
 </div>
 
-<h2>Open Source. Performant. Simple. Scalable.</h2>
+<h2>Open Source. Performant. Elegant. Scalable.</h2>
 <p class="lead">NATS acts as a central nervous system for distributed systems at scale, such as mobile devices, IoT networks, and cloud native infrastructure. Written in Go, NATS powers some of the largest cloud platforms in production today. Unlike traditional enterprise messaging systems, NATS has an always-on dial tone that does whatever it takes to remain available. NATS was created by Derek Collison, Founder/CEO of Apcera who has spent 20+ years designing, building, and using publish-subscribe messaging systems.</p>


### PR DESCRIPTION
Changed "Open Source. Performant. Simple. Scalable." on the homepage to "Open Source. Performant. Elegant. Scalable."