### PR TITLE
add socket.io-nats adapter to NATS Connectors

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -211,6 +211,12 @@ description = "NATS is a high performance messaging system that acts as a distri
         <td><a target="_blank" href="https://github.com/laugimethods">Laurent Magnin</a> at Logimethods</td>
         <td>Community</td>
       </tr>
+      <tr>
+        <td><a href="https://github.com/efmr/socket.io-nats" target="_blank">Socket.io-NATS Adapter</a></td>
+        <td>This library provides an adaptor to enable broadcasting of events to multiple separate socket.io server nodes through NATS.</td>
+        <td><a target="_blank" href="https://github.com/efmr">Edgar Ribeiro</a></td>
+        <td>Community</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/content/community.html
+++ b/content/community.html
@@ -212,8 +212,8 @@ description = "NATS is a high performance messaging system that acts as a distri
         <td>Community</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/efmr/socket.io-nats" target="_blank">Socket.io-NATS Adapter</a></td>
-        <td>This library provides an adaptor to enable broadcasting of events to multiple separate socket.io server nodes through NATS.</td>
+        <td><a href="https://github.com/efmr/socket.io-nats" target="_blank">Socket.io-NATS Connector</a></td>
+        <td>This connector enables multiple socket.io instances to broadcast and emit events to and from each other through NATS.</td>
         <td><a target="_blank" href="https://github.com/efmr">Edgar Ribeiro</a></td>
         <td>Community</td>
       </tr>


### PR DESCRIPTION
I made an adapter for Socket.io that allows to run a cluster of socket.io using NATS ([socket.io-nats](https://github.com/efmr/socket.io-nats)).

There's also an emitter ([socket.io-nats-emitter](https://github.com/efmr/socket.io-nats-emitter)) that emits these messages to non-socket.io servers.