### PR TITLE
Updated authorization link on page to point to correct URL

### DIFF
--- a/content/documentation/server/gnatsd-intro.md
+++ b/content/documentation/server/gnatsd-intro.md
@@ -20,7 +20,7 @@ NATS provides a [server binary](/documentation/tutorials/gnatsd-install/) for Li
 
 ## Usage
 
-The NATS server is easy to [use](/documentation/server/gnatsd-usage/), supports [authorization](/documentation/server/gnatsd-auth/), and provides [logging](/documentation/server/gnatsd-logging/) facilities.
+The NATS server is easy to [use](/documentation/server/gnatsd-usage/), supports [authorization](/documentation/server/gnatsd-authorization/), and provides [logging](/documentation/server/gnatsd-logging/) facilities.
 
 ## Configuration
 

--- a/content/documentation/server/gnatsd-usage.md
+++ b/content/documentation/server/gnatsd-usage.md
@@ -62,7 +62,7 @@ See [Logging](/documentation/server/gnatsd-logging).
         --user user                  User required for connections
         --pass password              Password required for connections
 
-See [Authorization](/documentation/server/gnatsd-auth).
+See [Authorization](/documentation/server/gnatsd-authorization).
 
 ## TLS Options
 


### PR DESCRIPTION
The previous link was pointing to a dead page (https://groups.google.com/forum/#!topic/natsio/IN7BNs-mDZI) -- should point to http://nats.io/documentation/server/gnatsd-authorization/