### PR TITLE
#89 update server install info

### DIFF
--- a/content/documentation/streaming/nats-streaming-install.md
+++ b/content/documentation/streaming/nats-streaming-install.md
@@ -87,9 +87,9 @@ When the server starts successfully, you will see that the NATS Streaming server
 [18085] 2016/10/31 13:11:44.396859 [INF] STAN: --------------------------------
 ```
 
-### Start the NATS Streaming Server with monitoring enabled (optional)
+### Start the NATS Streaming Server with NATS monitoring enabled (optional)
 
-The NATS Streaming server exposes a monitoring interface on port 8222.
+The NATS Streaming server exposes the monitoring interface of its embedded NATS Server (`gnatsd`) on port 8222.
 
 ```
 nats-streaming-server -m 8222

--- a/content/documentation/streaming/nats-streaming-install.md
+++ b/content/documentation/streaming/nats-streaming-install.md
@@ -12,19 +12,28 @@ category = "tutorials"
 
 # Install and Run NATS Streaming Server
 
-In this tutorial you install and run the NATS server (`nats-streaming-server`). You can follow this same procedure anytime you want to run the NATS Streaming server.
+In this tutorial you install and run the NATS Streaming server (`nats-streaming-server`). 
+You can follow this same procedure anytime you want to run the NATS Streaming server.
 
-## Prerequisite
 
-- [Set up your Go environment](/documentation/tutorials/go-install/)
+### Install the NATS Streaming server
 
-## Instructions
+There are numerous ways to install the NATS Streaming server.
 
-**1. Install the NATS Streaming server.**
+#### GitHub releases
 
-To install the latest released version of the NATS Streaming server, download one of the pre-built release binaries which are available for OSX, Linux (x86-64/ARM), and Windows. Instructions for using these binaries are on the [GitHub releases page](https://github.com/nats-io/nats-streaming-server/releases). 
+The latest official release binaries are always available on the [GitHub releases page](https://github.com/nats-io/nats-streaming-server/releases). 
+The following platforms are available:
 
-Another way to install NATS is using Go:
+ * Linux (x86, x86_64, ARM)
+ * Windows (x86, x86_64)
+ * macOS
+
+The following methods may also be used. _Please note that these methods may not install the latest released version_:
+
+#### Go
+
+Make sure [your Go environment is set up](/documentation/tutorials/go-install/)
 
 ```
 go get github.com/nats-io/nats-streaming-server
@@ -32,7 +41,27 @@ go get github.com/nats-io/nats-streaming-server
 
 Note that this method may not install the latest released version.
 
-**2. Start the NATS Streaming server.**
+#### Docker Hub
+
+The latest [official Docker image](https://hub.docker.com/_/nats-streaming/) is always available on Docker Hub.
+
+#### Windows
+
+On Windows, the NATS Streaming server can also be installed via [Chocolatey](https://chocolatey.org/packages/nats-streaming-server):
+
+```
+choco install nats-streaming-server
+```
+
+#### macOS
+
+On macOS, the NATS Streaming server can alo be installed via [Homebrew](http://brewformulas.org/NatsStreamingServer):
+
+```
+brew install nats-streaming-server
+```
+
+### Start the NATS Streaming server
 
 You can invoke the NATS Streaming server binary, with no options and no configuration file, to start a server with acceptable standalone defaults (no authentication, no clustering).
 
@@ -43,15 +72,22 @@ nats-streaming-server
 When the server starts successfully, you will see that the NATS Streaming server listens for client connections on TCP Port 4222:
 
 ```
-[11455] 2016/06/10 12:31:07.880904 [INF] Starting nats-streaming-server[test-cluster] version 0.0.1.alpha
-[11455] 2016/06/10 12:31:07.883148 [INF] Starting nats-server version 0.8.2
-[11455] 2016/06/10 12:31:07.883170 [INF] Listening for client connections on localhost:4222
-[11455] 2016/06/10 12:31:07.886044 [INF] Server is ready
-[11455] 2016/06/10 12:31:07.967026 [INF] STAN: Message store is MEMORY
-[11455] 2016/06/10 12:31:07.967047 [INF] STAN: Maximum of 1000000 will be stored
+[18085] 2016/10/31 13:11:44.059012 [INF] Starting nats-streaming-server[test-cluster] version 0.3.1
+[18085] 2016/10/31 13:11:44.059830 [INF] Starting nats-server version 0.9.4
+[18085] 2016/10/31 13:11:44.061544 [INF] Listening for client connections on 0.0.0.0:4222
+[18085] 2016/10/31 13:11:44.061966 [INF] Server is ready
+[18085] 2016/10/31 13:11:44.396819 [INF] STAN: Message store is MEMORY
+[18085] 2016/10/31 13:11:44.396832 [INF] STAN: --------- Store Limits ---------
+[18085] 2016/10/31 13:11:44.396837 [INF] STAN: Channels:                  100 *
+[18085] 2016/10/31 13:11:44.396839 [INF] STAN: -------- channels limits -------
+[18085] 2016/10/31 13:11:44.396842 [INF] STAN:   Subscriptions:          1000 *
+[18085] 2016/10/31 13:11:44.396844 [INF] STAN:   Messages     :       1000000 *
+[18085] 2016/10/31 13:11:44.396855 [INF] STAN:   Bytes        :     976.56 MB *
+[18085] 2016/10/31 13:11:44.396858 [INF] STAN:   Age          :     unlimited *
+[18085] 2016/10/31 13:11:44.396859 [INF] STAN: --------------------------------
 ```
 
-**3. Start the NATS server with monitoring enabled.**
+### Start the NATS Streaming Server with monitoring enabled (optional)
 
 The NATS Streaming server exposes a monitoring interface on port 8222.
 
@@ -62,12 +98,18 @@ nats-streaming-server -m 8222
 If you run the NATS Streaming server with monitoring enabled, you see the following messages:
 
 ```
-[11456] 2016/06/10 12:31:07.880904 [INF] Starting nats-streaming-server[test-cluster] version 0.0.1.alpha
-[11456] 2016/06/10 12:31:07.883148 [INF] Starting nats-server version 0.8.2
-[11456] 2016/06/10 12:32:13.883156 [INF] Starting http monitor on :8222
-[11456] 2016/06/10 12:31:07.883170 [INF] Listening for client connections on localhost:4222
-[11456] 2016/06/10 12:31:07.886044 [INF] Server is ready
-[11456] 2016/06/10 12:31:07.967026 [INF] STAN: Message store is MEMORY
-[11456] 2016/06/10 12:31:07.967047 [INF] STAN: Maximum of 1000000 will be stored
+[18122] 2016/10/31 13:13:10.048663 [INF] Starting nats-streaming-server[test-cluster] version 0.3.1
+[18122] 2016/10/31 13:13:10.048843 [INF] Starting nats-server version 0.9.4
+[18122] 2016/10/31 13:13:10.048890 [INF] Starting http monitor on 0.0.0.0:8222
+[18122] 2016/10/31 13:13:10.048968 [INF] Listening for client connections on 0.0.0.0:4222
+[18122] 2016/10/31 13:13:10.048992 [INF] Server is ready
+[18122] 2016/10/31 13:13:10.388282 [INF] STAN: Message store is MEMORY
+[18122] 2016/10/31 13:13:10.388301 [INF] STAN: --------- Store Limits ---------
+[18122] 2016/10/31 13:13:10.388309 [INF] STAN: Channels:                  100 *
+[18122] 2016/10/31 13:13:10.388312 [INF] STAN: -------- channels limits -------
+[18122] 2016/10/31 13:13:10.388316 [INF] STAN:   Subscriptions:          1000 *
+[18122] 2016/10/31 13:13:10.388319 [INF] STAN:   Messages     :       1000000 *
+[18122] 2016/10/31 13:13:10.388333 [INF] STAN:   Bytes        :     976.56 MB *
+[18122] 2016/10/31 13:13:10.388338 [INF] STAN:   Age          :     unlimited *
+[18122] 2016/10/31 13:13:10.388341 [INF] STAN: --------------------------------
 ```
-

--- a/content/documentation/streaming/nats-streaming-protocol.md
+++ b/content/documentation/streaming/nats-streaming-protocol.md
@@ -4,7 +4,7 @@ title = "NATS Streaming Protocol"
 category = "internals"
 [menu.main]
   name = "NATS Streaming Protocol"
-  weight = 1
+  weight = 2
   identifier = "internals-nats-streaming-protocol"
   parent = "Streaming"
 +++

--- a/content/documentation/tutorials/gnatsd-install.md
+++ b/content/documentation/tutorials/gnatsd-install.md
@@ -7,34 +7,59 @@ category = "tutorials"
   name = "Install NATS Server"
   weight = 2
   identifier = "tutorial-gnatsd-install"
-  parent = "Tutorials"
+  parent = "Server"
 +++
 
 # Install and Run NATS Server
 
 In this tutorial you install and run the NATS server (`gnatsd`). You can follow this same procedure anytime you want to run the NATS server.
 
-## Prerequisite
+### Install the NATS server
 
-- [Set up your Go environment](/documentation/tutorials/go-install/)
+There are numerous ways to install the NATS server.
 
-## Instructions
+#### Go
 
-**1. Install the NATS server.**
-
-To install the latest released version of the NATS server, download one of the pre-built release binaries which are available for OSX, Linux (x86-64/ARM), and Windows. Instructions for using these binaries are on the [GitHub releases page](https://github.com/nats-io/gnatsd/releases). 
-
-You can also install the latest version of the NATS server using the [official Docker image](https://hub.docker.com/_/nats/).
-
-Another way to install NATS is using Go:
+Make sure [your Go environment is set up](/documentation/tutorials/go-install/)
 
 ```
 go get github.com/nats-io/gnatsd
 ```
 
+#### GitHub releases
+
+Pre-built release binaries are always available on the [GitHub releases page](https://github.com/nats-io/gnatsd/releases). 
+The following platforms are available:
+
+ * Linux (x86, x86_64, ARM)
+ * Windows (x86, x86_64)
+ * macOS
+
+
+#### Docker Hub
+
+The latest [official Docker image](https://hub.docker.com/_/nats/) is always available on Docker Hub.
+
+
+#### Windows
+
+On Windows, the NATS server can also be installed via [Chocolatey](https://chocolatey.org/packages/gnatsd):
+
+```
+choco install gnatsd
+```
+
+#### macOS
+
+On macOS, the NATS server can alo be installed via [Homebrew](http://brewformulas.org/Gnatsd):
+
+```
+brew install gnatsd
+```
+
 Note that this method may not install the latest released version.
 
-**2. Start the NATS server.**
+### Start the NATS server
 
 You can invoke the NATS server binary, with no options and no configuration file, to start a server with acceptable standalone defaults (no authentication, no clustering).
 
@@ -50,7 +75,7 @@ When the server starts successfully, you will see that the NATS server listens f
 [35483] 2016/05/09 22:00:56.968883 [INF] Server is ready
 ```
 
-**3. Start the NATS server with monitoring enabled.**
+### Starting the NATS server with monitoring enabled (optional)
 
 The NATS server exposes a monitoring interface on port 8222.
 
@@ -67,7 +92,7 @@ If you run the NATS server with monitoring enabled, you see the following messag
 [35490] 2016/05/09 22:13:35.523849 [INF] Server is ready
 ```
 
-**4. Start the NATS server with routes enabled.**
+### Starting the NATS server with routes enabled (optional)
 
 If routing is enabled, route (server) connections listen on port 6222.
 

--- a/content/documentation/tutorials/gnatsd-install.md
+++ b/content/documentation/tutorials/gnatsd-install.md
@@ -12,11 +12,23 @@ category = "tutorials"
 
 # Install and Run NATS Server
 
-In this tutorial you install and run the NATS server (`gnatsd`). You can follow this same procedure anytime you want to run the NATS server.
+In this tutorial you install and run the NATS server (`gnatsd`). 
+You can follow this same procedure anytime you want to run the NATS server.
 
 ### Install the NATS server
 
 There are numerous ways to install the NATS server.
+
+#### GitHub releases
+
+The latest official release binaries are always available on the [GitHub releases page](https://github.com/nats-io/gnatsd/releases). 
+The following platforms are available:
+
+ * Linux (x86, x86_64, ARM)
+ * Windows (x86, x86_64)
+ * macOS
+
+**The following methods may also be used. _Please note that these methods may not install the latest released version_:**
 
 #### Go
 
@@ -25,16 +37,6 @@ Make sure [your Go environment is set up](/documentation/tutorials/go-install/)
 ```
 go get github.com/nats-io/gnatsd
 ```
-
-#### GitHub releases
-
-Pre-built release binaries are always available on the [GitHub releases page](https://github.com/nats-io/gnatsd/releases). 
-The following platforms are available:
-
- * Linux (x86, x86_64, ARM)
- * Windows (x86, x86_64)
- * macOS
-
 
 #### Docker Hub
 
@@ -57,8 +59,6 @@ On macOS, the NATS server can alo be installed via [Homebrew](http://brewformula
 brew install gnatsd
 ```
 
-Note that this method may not install the latest released version.
-
 ### Start the NATS server
 
 You can invoke the NATS server binary, with no options and no configuration file, to start a server with acceptable standalone defaults (no authentication, no clustering).
@@ -70,9 +70,9 @@ gnatsd
 When the server starts successfully, you will see that the NATS server listens for client connections on TCP Port 4222:
 
 ```
-[35483] 2016/05/09 22:00:56.966499 [INF] Starting nats-server version 0.8.0
-[35483] 2016/05/09 22:00:56.966658 [INF] Listening for client connections on 0.0.0.0:4222
-[35483] 2016/05/09 22:00:56.968883 [INF] Server is ready
+[18141] 2016/10/31 13:13:40.732616 [INF] Starting nats-server version 0.9.4
+[18141] 2016/10/31 13:13:40.732704 [INF] Listening for client connections on 0.0.0.0:4222
+[18141] 2016/10/31 13:13:40.732967 [INF] Server is ready
 ```
 
 ### Starting the NATS server with monitoring enabled (optional)
@@ -86,10 +86,10 @@ gnatsd -m 8222
 If you run the NATS server with monitoring enabled, you see the following messages:
 
 ```
-[35490] 2016/05/09 22:13:35.523638 [INF] Starting nats-server version 0.8.0
-[35490] 2016/05/09 22:13:35.523738 [INF] Starting http monitor on 0.0.0.0:8222
-[35490] 2016/05/09 22:13:35.523823 [INF] Listening for client connections on 0.0.0.0:4222
-[35490] 2016/05/09 22:13:35.523849 [INF] Server is ready
+[18159] 2016/10/31 13:14:03.055572 [INF] Starting nats-server version 0.9.4
+[18159] 2016/10/31 13:14:03.055692 [INF] Starting http monitor on 0.0.0.0:8222
+[18159] 2016/10/31 13:14:03.055762 [INF] Listening for client connections on 0.0.0.0:4222
+[18159] 2016/10/31 13:14:03.055796 [INF] Server is ready
 ```
 
 ### Starting the NATS server with routes enabled (optional)
@@ -97,9 +97,9 @@ If you run the NATS server with monitoring enabled, you see the following messag
 If routing is enabled, route (server) connections listen on port 6222.
 
 ```
-[35490] 2016/05/09 22:13:35.523638 [INF] Starting nats-server version 0.8.0
-[35490] 2016/05/09 22:13:35.523738 [INF] Starting http monitor on 0.0.0.0:8222
-[35490] 2015/08/12 15:18:22.301707 [INF] Listening for route connections on 0.0.0.0:6222
-[35490] 2016/05/09 22:13:35.523823 [INF] Listening for client connections on 0.0.0.0:4222
-[35490] 2016/05/09 22:13:35.523849 [INF] Server is ready
+[18159] 2016/10/31 13:14:03.055572 [INF] Starting nats-server version 0.9.4
+[18159] 2016/10/31 13:14:03.055692 [INF] Starting http monitor on 0.0.0.0:8222
+[18159] 2016/10/31 13:14:03.055707 [INF] Listening for route connections on 0.0.0.0:6222
+[18159] 2016/10/31 13:14:03.055762 [INF] Listening for client connections on 0.0.0.0:4222
+[18159] 2016/10/31 13:14:03.055796 [INF] Server is ready
 ```


### PR DESCRIPTION
1. Moved the `gnatsd` install tutorial to the "Server" box, in second position
2. Moved the `nats-streaming-server` install tutorial to the second position in the "Streaming" box
3. Reorganized the install info to flow a bit better (and removed the numbering of steps)
4. Updated output examples to latest versions of `gnatsd` and `nats-streaming-server`

/cc @nats-io/core 