### PR TITLE
Unrendered markdown - Placing angle brackets in explanation inside of preformatted backticks

### DIFF
--- a/content/documentation/tutorials/nats-pub-sub.md
+++ b/content/documentation/tutorials/nats-pub-sub.md
@@ -55,7 +55,7 @@ cd $GOPATH/src/github.com/nats-io/nats/examples
 go run nats-sub.go <subject>
 ```
 
-Where <subject> is a subject to listen on. A valid subject is a string that is unique in the system.
+Where `<subject>` is a subject to listen on. A valid subject is a string that is unique in the system.
 
 For example:
 
@@ -81,7 +81,7 @@ cd $GOPATH/src/github.com/nats-io/nats/examples
 go run nats-pub.go <subject> <"message”>
 ```
 
-Where <subject> is the subject name and <"message”> is a message to publish.
+Where `<subject>` is the subject name and `<"message”>` is a message to publish.
 
 For example:
 


### PR DESCRIPTION
The sentences currently read:
"Where is a subject to listen on..." AND
"Where is the subject name and <“message”> is a message to publish."
 - This fix will render on page as:
"Where <subject> is a subject to listen on..."
"Where <subject> is the subject name and <“message”> is a message to publish."

It looks like the regular angle brackets that aren't escaped or inside of backticks are being recognized as html from the markdown document (invalid html element obviously).

In the two lines that explain the preformatted go run commands do not render the word subject.  Placing <subject> inside of backticks so that it is rendered in the explanation of the command, and placing <message> inside of backticks for the sake of consistency.