### PR TITLE
Incomplete sentence pub-sub concept

### DIFF
--- a/content/documentation/concepts/nats-pub-sub.md
+++ b/content/documentation/concepts/nats-pub-sub.md
@@ -19,7 +19,7 @@ In an asynchronous exchange, messages are delivered to the subscriber's message 
 
 - **At Most Once Delivery (TCP reliability)** - In the basic NATS platform, if a subscriber is not listening on the subject (no subject match), or is not active when the message is sent, the message is not received. NATS is a fire-and-forget messaging system. If you need higher levels of service, you can either use [NATS Streaming](/documentation/streaming/nats-streaming-intro/), or build the additional reliability into your client(s) yourself.
 
-- **At Least Once Delivery ([NATS Streaming](/documentation/streaming/nats-streaming-intro/))** - Some applications require higher levels of service and more stringent delivery guarantees, at the potential cost of lower message throughput and higher end-to-end delivery latency. These applications rely on the underlying messaging transport to ensure that messages are delivered to subscribers irrespective of network outages or whether or not a subscriber is offline at a particular instant in time. These 
+- **At Least Once Delivery ([NATS Streaming](/documentation/streaming/nats-streaming-intro/))** - Some applications require higher levels of service and more stringent delivery guarantees, at the potential cost of lower message throughput and higher end-to-end delivery latency. These applications rely on the underlying messaging transport to ensure that messages are delivered to subscribers irrespective of network outages or whether or not a subscriber is offline at a particular instant in time.
 
 
 

--- a/content/documentation/tutorials/nats-pub-sub.md
+++ b/content/documentation/tutorials/nats-pub-sub.md
@@ -86,6 +86,11 @@ Where `<subject>` is the subject name and `<message>` is the text to publish.
 For example:
 
 ```
+go run nats-pub.go msg.test hello
+```
+or
+
+```
 go run nats-pub.go msg.test "NATS MESSAGE"
 ```
 

--- a/content/documentation/tutorials/nats-pub-sub.md
+++ b/content/documentation/tutorials/nats-pub-sub.md
@@ -55,7 +55,7 @@ cd $GOPATH/src/github.com/nats-io/nats/examples
 go run nats-sub.go <subject>
 ```
 
-Where <subject> is a subject to listen on. A valid subject is a string that is unique in the system.
+Where `<subject>` is a subject to listen on. A valid subject is a string that is unique in the system.
 
 For example:
 
@@ -81,7 +81,7 @@ cd $GOPATH/src/github.com/nats-io/nats/examples
 go run nats-pub.go <subject> <"message”>
 ```
 
-Where <subject> is the subject name and <"message”> is a message to publish.
+Where `<subject>` is the subject name and `<"message”>` is a message to publish.
 
 For example:
 

--- a/content/documentation/tutorials/nats-pub-sub.md
+++ b/content/documentation/tutorials/nats-pub-sub.md
@@ -43,7 +43,7 @@ The NATS server listens for client connections on TCP Port 4222.
 
 You will use this session to run an example NATS client subscriber program.
 
-**3. CD to the example Go client directory.**
+**3. CD to the Go client examples directory.**
 
 ```
 cd $GOPATH/src/github.com/nats-io/nats/examples
@@ -78,10 +78,10 @@ cd $GOPATH/src/github.com/nats-io/nats/examples
 **7. Publish a NATS message.**
 
 ```
-go run nats-pub.go <subject> <"message”>
+go run nats-pub.go <subject> <message>
 ```
 
-Where `<subject>` is the subject name and `<"message”>` is a message to publish.
+Where `<subject>` is the subject name and `<message>` is the text to publish.
 
 For example:
 


### PR DESCRIPTION
At the end of the pub sub 'concept,' a sentence was started but not finished.  Removing this to avoid confusion.
