### PR TITLE
Updating import path with new Go Client repo name

### DIFF
--- a/content/blog/docker-compose-plus-nats.md
+++ b/content/blog/docker-compose-plus-nats.md
@@ -47,7 +47,7 @@ import (
   "os"
   "time"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 type server struct {
@@ -116,7 +116,7 @@ import (
   "os"
   "time"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 func healthz(w http.ResponseWriter, r *http.Request) {

--- a/content/blog/natsproxy_project.md
+++ b/content/blog/natsproxy_project.md
@@ -64,7 +64,7 @@ The proxy side implements the `http.Handler` interface, so it can be used with b
 import(
         "gopkg.in/sohlich/nats-proxy.v1"
         "net/http"
-        "github.com/nats-io/nats"
+        "github.com/nats-io/go-nats"
     )
 
 func main() {
@@ -96,7 +96,7 @@ The client code uses the nats connection as the constructor argument, so all ava
 import(
     "gopkg.in/sohlich/nats-proxy.v1"
     "net/http"
-    "github.com/nats-io/nats"
+    "github.com/nats-io/go-nats"
 )
 
 func main(){

--- a/content/documentation/tutorials/examples/async-sub.go
+++ b/content/documentation/tutorials/examples/async-sub.go
@@ -4,27 +4,27 @@ package main
 
 // Import packages
 import (
-  "runtime"
-  "log"
+	"log"
+	"runtime"
 
-  "github.com/nats-io/nats"
-) 
+	"github.com/nats-io/go-nats"
+)
 
 func main() {
 
-    // Create server connection: auth and no auth
-    // natsConnection, _ := nats.Connect("nats://foo:bar@localhost:4222")
-    natsConnection, _ := nats.Connect(nats.DefaultURL)
-    log.Println("Connected to " + nats.DefaultURL)
+	// Create server connection: auth and no auth
+	// natsConnection, _ := nats.Connect("nats://foo:bar@localhost:4222")
+	natsConnection, _ := nats.Connect(nats.DefaultURL)
+	log.Println("Connected to " + nats.DefaultURL)
 
-    // Subscribe to subject
-    log.Printf("Subscribing to subject 'foo'\n")
-    natsConnection.Subscribe("foo", func(msg *nats.Msg) {
-      
-      // Handle the message
-      log.Printf("Received message '%s\n", string(msg.Data) + "'")
-  })
+	// Subscribe to subject
+	log.Printf("Subscribing to subject 'foo'\n")
+	natsConnection.Subscribe("foo", func(msg *nats.Msg) {
 
-  // Keep the connection alive
-  runtime.Goexit()
+		// Handle the message
+		log.Printf("Received message '%s\n", string(msg.Data)+"'")
+	})
+
+	// Keep the connection alive
+	runtime.Goexit()
 }

--- a/content/documentation/tutorials/examples/nats-rep.go
+++ b/content/documentation/tutorials/examples/nats-rep.go
@@ -2,7 +2,7 @@ package main
 
 import (
         "fmt"
-        "github.com/nats-io/nats"
+        "github.com/nats-io/go-nats"
 )
 
 func main(){

--- a/content/documentation/tutorials/examples/nats-req.go
+++ b/content/documentation/tutorials/examples/nats-req.go
@@ -3,7 +3,7 @@ package main
 import (
         "fmt"
         "time"
-        "github.com/nats-io/nats"
+        "github.com/nats-io/go-nats"
 )
 
 func main(){

--- a/content/documentation/tutorials/examples/pub-msg.go
+++ b/content/documentation/tutorials/examples/pub-msg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )	
 
 func main() {

--- a/content/documentation/tutorials/examples/pub-simple.go
+++ b/content/documentation/tutorials/examples/pub-simple.go
@@ -6,7 +6,7 @@ package main
 import (
 	"log"
 
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )	
 
 func main() {

--- a/content/documentation/tutorials/nats-client-dev.md
+++ b/content/documentation/tutorials/nats-client-dev.md
@@ -40,7 +40,7 @@ import (
   "runtime"
   "log"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 func main() {
@@ -111,7 +111,7 @@ package main
 import (
   "log"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 func main() {
@@ -171,7 +171,7 @@ import (
   "fmt"
   "log"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 func main() {
@@ -221,7 +221,7 @@ import (
   "runtime"
   "log"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 func main() {
@@ -251,7 +251,7 @@ package main
 import (
   "log"
 
-  "github.com/nats-io/nats"
+  "github.com/nats-io/go-nats"
 )
 
 func main() {


### PR DESCRIPTION
Changing the import path of the Go client in the example code and markdown docs.