### PR TITLE
Explain credentials in Docker cluster config sample

### DIFF
--- a/content/documentation/server/gnatsd-container.md
+++ b/content/documentation/server/gnatsd-container.md
@@ -61,13 +61,13 @@ $ docker run -d -p 4222:4222 -p 6222:6222 -p 8222:8222 --name nats-main nats
 To run a second server and cluster them together:
 
 ```
-$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://ruser:T0pS3cr3t@nats-main:6222
+$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://nats-main:6222
 ```
 
 To verify the routes are connected:
 
 ```
-$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://ruser:T0pS3cr3t@nats-main:6222 -DV
+$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://nats-main:6222 -DV
 [INF] Starting gnatsd version 0.6.6
 [INF] Starting http monitor on port 8222
 [INF] Listening for route connections on :6222

--- a/content/documentation/server/gnatsd-container.md
+++ b/content/documentation/server/gnatsd-container.md
@@ -61,13 +61,24 @@ $ docker run -d -p 4222:4222 -p 6222:6222 -p 8222:8222 --name nats-main nats
 To run a second server and cluster them together:
 
 ```
-$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://nats-main:6222
+$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://ruser:T0pS3cr3t@nats-main:6222
+```
+
+**NOTE** Since the Docker image protects routes using credentials we need to provide them above. Extracted [from Docker image configuration](https://github.com/nats-io/nats-docker/blob/master/gnatsd.conf#L16-L20)
+```
+# Routes are protected, so need to use them with --routes flag
+# e.g. --routes=nats-route://ruser:T0pS3cr3t@otherdockerhost:6222
+authorization {
+  user: ruser
+  password: T0pS3cr3t
+  timeout: 2
+}
 ```
 
 To verify the routes are connected:
 
 ```
-$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://nats-main:6222 -DV
+$ docker run -d --name=nats-2 --link nats-main nats --routes=nats-route://ruser:T0pS3cr3t@nats-main:6222 -DV
 [INF] Starting gnatsd version 0.6.6
 [INF] Starting http monitor on port 8222
 [INF] Listening for route connections on :6222


### PR DESCRIPTION
~~It confuses the sample as it is not used in the first case, nor is it explained either.~~

Later commit adds it back and tries to clarify why the credentials are there.