### PR TITLE
Add CONNECT protocol info

### DIFF
--- a/content/documentation/internals/nats-protocol.md
+++ b/content/documentation/internals/nats-protocol.md
@@ -117,6 +117,7 @@ The valid options are as follows:
 * `name`: Optional client name
 * `lang`: The implementation language of the client.
 * `version`: The version of the client.
+* `protocol`: optional, passing `1` indicates that the client supports dynamic reconfiguration of cluster topology changes
 
 ### Description
 The `CONNECT` message is analogous to the `INFO` message. Once the client has established a TCP/IP socket connection with the NATS server, and an `INFO` message has been received from the server, the client may send a `CONNECT` message to the NATS server to provide more information about the current connection as well as security information.

--- a/content/documentation/internals/nats-protocol.md
+++ b/content/documentation/internals/nats-protocol.md
@@ -117,7 +117,7 @@ The valid options are as follows:
 * `name`: Optional client name
 * `lang`: The implementation language of the client.
 * `version`: The version of the client.
-* `protocol`: optional, passing `1` indicates that the client supports dynamic reconfiguration of cluster topology changes
+* `protocol`: *optional int*. Sending `0` (or absent) indicates client supports original protocol. Sending `1` indicates that the client supports dynamic reconfiguration of cluster topology changes by asynchronously receiving `INFO` messages with known servers it can reconnect to.
 
 ### Description
 The `CONNECT` message is analogous to the `INFO` message. Once the client has established a TCP/IP socket connection with the NATS server, and an `INFO` message has been received from the server, the client may send a `CONNECT` message to the NATS server to provide more information about the current connection as well as security information.


### PR DESCRIPTION
Not really sure what the valid values are and if it's a numeric value or a string. I got it presented as an integer over Slack. And basically `NULL` (or other than `1`) means not supported.

Feel free to correct/comment on this so that it becomes correct.