### PR TITLE
Update gnatsd-docker.md

### DIFF
--- a/content/documentation/tutorials/gnatsd-docker.md
+++ b/content/documentation/tutorials/gnatsd-docker.md
@@ -26,7 +26,7 @@ The easiest way to run Docker is to use the [Docker Toolbox](http://docs.docker.
 **2. Run the gnatsd Docker image.**
 
 ```
-docker run -p 4222:4222 -p 8222:8222 nats
+$ docker run -p 4222:4222 -p 8222:8222 -p 6222:6222 --name gnatsd -ti nats:latest
 ```
 
 **3. Verify that the NATS server is running.**
@@ -59,7 +59,7 @@ Notice how quickly the NATS server Docker image downloads. It is a mere 6 MB in 
 An easy way to test the client connection port is through using telnet.
 
 ```
-telnet localhost 4222
+$ telnet localhost 4222
 ```
 
 Expected result:


### PR DESCRIPTION
* Usage $ to indicate what is to be typed in and what is output.

* Map missing port 6222
* Assign name for container management

* Use `-ti` so that container can be detached with Control + p + q

* Be specific about the tag - `nats:latest`

Also - this content doesn't appear to be published yet? The published version references Apcera in the output.