### PR TITLE
Fix bench examples

### DIFF
--- a/content/documentation/tutorials/go-install.md
+++ b/content/documentation/tutorials/go-install.md
@@ -34,7 +34,7 @@ Follow the instructions for your platform to install the Go tools: [https://gola
 
 Your Go working directory (GOPATH) is where you store your Go code. It can be any path you choose but must be separate from your Go installation directory (GOROOT).
 
-The following instructions describe how to set your GOPATH. Refer to the official Go documentation for more details: [https://golang.org/doc/code.html](https://golang.org/doc/code.html).
+The following instructions describe one way you can set your GOPATH. Refer to the official Go documentation for more details: [https://golang.org/doc/code.html](https://golang.org/doc/code.html).
 
 **Mac OS X and Linux**
 
@@ -52,18 +52,18 @@ The following instructions describe how to set your GOPATH. Refer to the officia
 
 **Windows**
 
-- Create a working directory that is not the same as your Go installation, such as `C:\Users\HOME\go`, where HOME is your default directory.
+- Create a working directory that is not the same as your Go installation, for example, `C:\Users\%USERNAME%\go`, where is your default directory.
 
 - Create the GOPATH environment variable:
 
 	```
-	GOPATH = C:\Users\HOME\
+	set GOPATH=c:\Users\%USERNAME%\go
 	```
 
 - Add the GOPATH\bin environment variable to your PATH:
 
 	```
-	PATH = %GOPATH%bin
+	set PATH=%PATH%;%GOPATH%\bin
 	```
 
 - Create the required Go directory structure for your source code:

--- a/content/documentation/tutorials/nats-benchmarking.md
+++ b/content/documentation/tutorials/nats-benchmarking.md
@@ -38,18 +38,22 @@ Verify that the NATS server starts successfully, as well as the HTTP monitor:
 
 ### Installing and running the benchmark utility 
 
-Thanks to the power of Go, you can either install the `nats-bench` utility in `$GOBIN`:
+The NATS benchmark can be installed and run via Go.  Ensure your golang environment is setup.
+
+There are two approaches; you can either install the `nats-bench` utility in the directory specified in your `GOBIN` environment variable:
 ```
-go install $GOPATH/src/github.com/nats-io/nats/examples/nats-bench.go
+go install $GOPATH/src/github.com/nats-io/go-nats/examples/nats-bench.go
 ```
 
 ... or you can simply run it via `go run`:
 
 ```
-go run $GOPATH/src/github.com/nats-io/nats/examples/nats-bench.go
+go run $GOPATH/src/github.com/nats-io/go-nats/examples/nats-bench.go
 ```
 
-For the purpose of this tutorial, we'll assume that you chose the first option, and that you've added `$GOBIN` to your `PATH`. 
+*On windows use the % environment variable syntax, replacing `$GOPATH` with `%GOPATH%`.*
+
+For the purpose of this tutorial, we'll assume that you chose the first option, and that you've added the `GOBIN` environment variable to your `PATH`. 
 
 ### Usage
 


### PR DESCRIPTION
* Fixed benchmark examples.  They were referencing the old NATS repo name.
* Added a note for windows users.  Note that the `/` path separator works on windows with go.
* Fixed the windows install instructions.