### PR TITLE
add go get golang.org/x/crypto/ssh/terminal to content/documentation/managing_the_server/security.md

### DIFF
--- a/content/documentation/managing_the_server/security.md
+++ b/content/documentation/managing_the_server/security.md
@@ -125,6 +125,7 @@ In addition to TLS functionality, the server now also supports hashing of passwo
 A utility for creating `bcrypt` hashes is included with the gnatsd distribution (`util/mkpasswd.go`). Running it with no arguments will generate a new secure password along with the associated hash. This can be used for a password or a token in the configuration. 
 
 ```
+~/go/src/github.com/nats-io/gnatsd/util> go get golang.org/x/crypto/ssh/terminal
 ~/go/src/github.com/nats-io/gnatsd/util> go build mkpasswd.go
 ~/go/src/github.com/nats-io/gnatsd/util> ./mkpasswd
 pass: #IclkRPHUpsTmACWzmIGXr


### PR DESCRIPTION
add go get golang.org/x/crypto/ssh/terminal before compiling mkpasswd.go to content/documentation/managing_the_server/security.md