### PR TITLE
Fix Markdown formatting for link rendering

### DIFF
--- a/content/blog/openIoT.md
+++ b/content/blog/openIoT.md
@@ -12,22 +12,21 @@ The [Linux Foundation’s](https://twitter.com/linuxfoundation) [OpenIoT Summit]
   <iframe width="560" height="315" src="https://www.youtube.com/embed/6uPopWEdldU" frameborder="0" allowfullscreen></iframe>
 </div>
 
-The slides Larry presents in the talk are available via (SlideShare)[http://www.slideshare.net/Apcera/nats-a-central-nervous-system-for-iot-messaging-larry-mcqueary].
+The slides Larry presents in the talk are available via [SlideShare](http://www.slideshare.net/Apcera/nats-a-central-nervous-system-for-iot-messaging-larry-mcqueary).
 
 <iframe src="//www.slideshare.net/slideshow/embed_code/key/8ASh85n4erfhQa" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen></iframe>
 
-Among the key points Larry makes is that traditional messaging systems disappoint because:
+Among the key points Larry makes are that traditional messaging systems disappoint because:
 
 * They try to do too much
 * Performance and stability are not enough of a priority - functionality is
 * They carry too many dependencies
 * They get generalized over time, and lose their initial focus and intent
 
-If you are at all familiar with NATS you know NATS is the opposite of this. NATS is all about simplicity and performance, and has no external dependencies. It’s a simple plain-text protocol. The Docker image is a mere 7MB, and the client libraries are just a few hundred K in size.
+If you are at all familiar with NATS, you know NATS is the opposite of this. NATS is all about simplicity and performance, and has no external dependencies. It’s a simple plain-text protocol. The Docker image is a mere 7MB, and the client libraries are just a few hundred K in size.
 
 The lightweight, high performance profile of NATS make it ideal for IoT messaging where device characteristics and communication patterns mean a heavy, general purpose messaging system won’t scale.
 
 If you’re considering IoT development, and look for a messaging layer we would be interested to hear from you! You might also want to take a look at the [NATS Arduino client](http://nats.io/download/joshglendenning/arduino-nats/) developed by the Community.
-
 
 You can continue the conversation with us on [Twitter](https://twitter.com/nats_io), or join the [NATS Community](http://nats.io/community/) and let us know your thoughts.


### PR DESCRIPTION
Fixed format to use `[text](url)` instead of the earlier `(text)[url]` which does not render correctly on the site: https://nats.io/blog/openiot/

Additional cleanups:

- fixed grammar (agreement in number: "among the key points ... are"); though further editing/rewriting might be warranted
- added missing comma
- removed extra blank line