### PR TITLE
Minify via Hugo instead of external tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,9 @@ install:
   - sudo dpkg -i hugo*.deb
   - npm install
   - npm install --global gulp-cli
-  - wget https://github.com/tdewolff/minify/releases/download/v2.3.4/minify_2.3.4_linux_amd64.tar.gz
-  - mkdir ./tools
-  - tar -xf minify_2.3.4_linux_amd64.tar.gz -C ./tools
 
 script:
   - gulp build
-  - ./tools/minify --html-keep-conditional-comments --html-keep-document-tags --html-keep-end-tags -r -o public/ -a public/
   - if [[ "$TRAVIS_TAG" != "" ]]; then mv ./public site_$TRAVIS_TAG; fi
   - if [[ "$TRAVIS_TAG" != "" ]]; then zip site_$TRAVIS_TAG.zip -r site_$TRAVIS_TAG; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       - graphicsmagick
 
 install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.42/hugo_0.42_Linux-64bit.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.54/hugo_0.54_Linux-64bit.deb
   - sudo dpkg -i hugo*.deb
   - npm install
   - npm install --global gulp-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       - graphicsmagick
 
 install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.54/hugo_0.54_Linux-64bit.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.53/hugo_0.53_Linux-64bit.deb
   - sudo dpkg -i hugo*.deb
   - npm install
   - npm install --global gulp-cli

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,8 @@ setup:
 build:
 	$(GULP) build
 
-minify:
-	minify --html-keep-conditional-comments --html-keep-document-tags --html-keep-end-tags -r -o public/ -a public/
-
 clean:
 	$(GULP) clean
-
 
 deploy:
 	cd public; s3cmd sync . s3://test.nats.io/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('clean', function() {
 });
 
 // HUGO
-gulp.task('hugo', shell.task('hugo'));
+gulp.task('hugo', shell.task('hugo --minify'));
 
 // // Watch
  gulp.task('watch', function() {


### PR DESCRIPTION
The current minification process is creating stylistic issues, for example in the "Edit on GitHub" button. This PR moves the minification process to Hugo, which should eliminate those problems. An added benefit is that the `minify` tool is no longer necessary for site deployment.