### PR TITLE
Remove extra padding from nav list

### DIFF
--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -866,7 +866,7 @@ code[data-viz] {
         }
 
         ul {
-          padding: 2px 0px 20px 0px;
+          padding: 0;
           li {
             white-space: nowrap;
             overflow: hidden;


### PR DESCRIPTION
This PR removes the extra padding from the panels in the left-hand nav for documentation. Preview:

https://deploy-preview-424--nats-io.netlify.com/documentation/