### PR TITLE
redirecting monitoring doc

### DIFF
--- a/content/documentation/server/monitoring.html
+++ b/content/documentation/server/monitoring.html
@@ -1,0 +1,5 @@
+
+<head>
+    <title>Monitoring</title>
+    <meta http-equiv="refresh" content="0;URL='https://nats-io.github.io/docs/nats_server/monitoring.html'" />
+</head>


### PR DESCRIPTION
updating documentation/server/monitoring to redirect to nats-io/github.io/docs/nats_server/monitoring