### PR TITLE
Fix PGP/WKD setup to be invoked & work in Netlify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 ---
-sudo: required
 dist: bionic
 language: node_js
 
 node_js:
   - 9
-
-python:
-  - 3.6.x
 
 git:
   depth: false
@@ -29,6 +25,10 @@ script:
   - if [[ "$TRAVIS_TAG" != "" ]]; then mv ./public site_$TRAVIS_TAG; fi
   - if [[ "$TRAVIS_TAG" != "" ]]; then zip site_$TRAVIS_TAG.zip -r site_$TRAVIS_TAG; fi
 
+# "travis lint" complaints about skip_cleanup; looking at
+# https://docs.travis-ci.com/user/deployment-v2#cleaning-up-the-git-working-directory
+# I see that the deploy v2 approach is to skip by default, but that v1 is still
+# default, so we're leaving that option in. -- 2020-02
 deploy:
   - provider: releases
     api_key: $GITHUB_TOKEN

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,7 @@ gulp.task('hugo', shell.task('hugo --minify'));
 // OpenPGP WKD
 // <https://datatracker.ietf.org/doc/draft-koch-openpgp-webkey-service/?include_text=1>
 gulp.task('openpgp-wkd',
-	  shell.task('./pgp/standalone-update-website -d nats.io -k pgp/*.asc -o public'))
+	  shell.task('./pgp/update -v -d nats.io -k pgp/*.asc -o static'))
 
 // // Watch
  gulp.task('watch', function() {
@@ -124,12 +124,12 @@ gulp.task('help', function(){
   console.log('if gulp build fails, simply add ".pipe(plumber())" to the task to see the error');
 });
 
-gulp.task('assets', [ 'less', 'css', 'js', 'img', 'font', 'docsImages', 'userLogos', 'partnerLogos', 'blogImages', 'blogImagesGifs', 'collateral']);
+gulp.task('assets', [ 'less', 'css', 'js', 'img', 'font', 'docsImages', 'userLogos', 'partnerLogos', 'blogImages', 'blogImagesGifs', 'collateral', 'openpgp-wkd']);
 
 // Default Task
 // gulp.task('default', [ 'less', 'js', 'img', 'font', 'docsImages', 'userLogos', 'partnerLogos', 'blogImages', 'blogImagesGifs', 'watch' ]);
 
 // Build for Production
 gulp.task('build', function (callback) {
-  runSequence( 'clean', 'assets', 'hugo', 'openpgp-wkd', callback);
+  runSequence( 'clean', 'assets', 'hugo', callback);
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,8 @@ command = "make netlify-preview-build"
 
 [context.branch-deploy]
 command = "make netlify-preview-build"
+
+[[headers]]
+  for = "/.well-known/openpgpkey/hu/*"
+  [headers.values]
+  Content-Type = "application/octet-stream"

--- a/pgp/standalone-update-website
+++ b/pgp/standalone-update-website
@@ -146,6 +146,9 @@ class Email:
     def __str__(self):
         return self.lower
 
+    def __repr__(self):
+        return f'[<{self.lower}>,{self.wkd_local}]'
+
     def __lt__(self, other):
         return self.lower < other.lower
 
@@ -174,6 +177,9 @@ class GPGHandler:
             self._cmd(['--import', '--'], key_files),
             check=True, env=self.cmd_env)
 
+    def keyring_list(self):
+        subprocess.run(self._cmd(['--list-keys']), env=self.cmd_env)
+
     def raw_emails_in_keyring(self):
         lister = subprocess.Popen(
             self._cmd(['--with-colons', '--list-keys']),
@@ -185,10 +191,14 @@ class GPGHandler:
             line = lister.stdout.readline()
             if not line:
                 break
-            if not line.startswith('uid:'):
+            # All modern GnuPG uses the uid: field here, but some ancient GnuPG 1
+            # puts the email in the pub: field instead.
+            if not (line.startswith('uid:') or line.startswith('pub:')):
                 continue
             try:
                 uid_str = line.split(':')[9]
+                if not uid_str:
+                    continue
                 m = extract.search(uid_str)
                 if m:
                     yield Email(m.group(1))
@@ -222,15 +232,21 @@ def _main():
                         type=str, required=True, nargs='+',
                         metavar='FILE',
                         help='one or more PGP key files to scan')
+    parser.add_argument('-v', '--verbose',
+                        action='count', default=0,
+                        help='Be more verbose')
     parser.add_argument('--gpg-command',
                         type=str, default='gpg',
                         help='Change the gpg command to invoke [%(default)s]')
     options = parser.parse_args()
 
+    if options.verbose >= 2:
+        print('python: ' + sys.version)
+        print(repr(sys.argv))
+        print('key files: ' + repr(options.keys_file))
+
     allowed_domains = set(d.lower() for d in options.domain)
     output_dir = pathlib.Path(options.output_dir)
-    if not output_dir.exists():
-        raise Exit(f'output directory {shlex.quote(str(output_dir))} must exist')
 
     wkd_wellknown = output_dir / '.well-known' / 'openpgpkey'
     hu_dir = wkd_wellknown / 'hu'
@@ -244,11 +260,18 @@ def _main():
         sub_env['GNUPGHOME'] = gnupghome
         gpg = GPGHandler(options=options, cmd_env=sub_env)
         gpg.key_import(options.keys_file)
+        if options.verbose >= 3:
+            print('', end='', flush=True)
+            gpg.keyring_list()
         for email in gpg.emails_in_keyring():
             if email.domain not in allowed_domains:
+                if options.verbose >= 3:
+                    print(f'Skipping for bad domain: {email}')
                 continue
             with open(hu_dir / email.wkd_local, 'wb') as out:
                 gpg.export_binary_key(email=email, out=out)
+            if options.verbose:
+                print(f'pgp: created {email.wkd_local} for {email}')
 
 
 if __name__ == '__main__':

--- a/pgp/update
+++ b/pgp/update
@@ -1,0 +1,45 @@
+#!/bin/sh -eu
+set -eu
+
+# We have multiple versions of Python in different testing environments.
+#
+# Netlify: has 3.5 and 3.7 with 3 being a symlink to 3.5
+#  - problem: 3.5 has limited/broken pathlib support, our script fails
+#
+# Travis: the bionic runtime has no Python 3.7, no matter what their docs say,
+# at least when invoked with "language: node_js".
+# No `python` controllers affect that.
+# But a bare `python3` works.
+#
+# Rather than play self-re-exec games with the Python script, we wrap it with
+# this portability shim.
+
+PyCommandName='standalone-update-website'
+PyCommand="$(dirname "$0")/$PyCommandName"
+PyMinimum='(3, 6)'
+
+progname="$(basename "$0" .sh)"
+note() { printf >&2 '%s: %s\n' "$progname" "$*"; }
+
+okay=false
+for py_interp in python3 python3.8 python3.7 python3.6
+do
+  if $py_interp 2>/dev/null <<EOTEST
+import sys
+MIN_PY = $PyMinimum
+if sys.version_info < MIN_PY:
+  sys.exit(1)
+EOTEST
+  then
+    okay=true
+    break
+  fi
+done
+
+if ! $okay; then
+  note "unable to find an acceptable [>= $PyMinimum] Python interpreter"
+  exit 1
+fi
+
+note "Using Python interpreter $py_interp to run $PyCommand"
+exec "$py_interp" "$PyCommand" "$@"


### PR DESCRIPTION
1. Fix placement of WKD build in gulp cfg
   * The netlify make targets use gulp only to build `assets`, not `build`, so the `openpgp-wkd` task was not getting invoked in that flow.
2. Reconfigure `openpgp-wkd` to output into `static/` and invoke for the assets flow.  Remove requirement for the output dir to already exist, since these gulp tasks are run in parallel and we're no longer invoked in a later stage.
3. Find a way to get a sane working Python in both Netlify and Travis
   * Docker image `netlify/build:v3.3.5` contains two Python3 interpreters and defaults to the older one with buggy/limited pathlib support.
   * We can specify `python3.7` in the `#!` line but that breaks Travis, where for `language: node_js` we don't get to choose available Python interpreters.
   * So use a shell wrapper to find a working Python.
4. Ran `travis lint`, removed the meaningless sudo, commented the will-change-to-unused item.
5. Handle ancient GnuPG putting the email address in a different place.
6. Configure Netlify to serve PGP keys with a better MIME type.