### PR TITLE
Homepage: ensure video iframe fits narrow views

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -172,7 +172,7 @@ $colors: mergeColorMaps(("primary-dark": ($nats-dark-blue, $white), "light-green
 
 .logo
   margin: auto auto auto
-  
+
   +tablet-only
     width: 90%
   +touch
@@ -238,6 +238,10 @@ $colors: mergeColorMaps(("primary-dark": ($nats-dark-blue, $white), "light-green
 .is-user-logo
      height: 60%
      width: 60%
+
+.is-video
+  @include mobile
+    max-width: 100%
 
 .column
     &.has-text-centered


### PR DESCRIPTION
This addresses the main problem causing #632 by ensuring that the video iframe doesn't exceed the view width, whether on desktop or mobile. As a result, the video preview image is cropped under mobile, but this is one of the easiest fixes that doesn't involve further design changes. (The video itself, when viewed under mobile / narrow-views, displays w/o being cropped.)

Note that the video preview image is already being cropped, for example, when viewed under a tablet, so I figured that this solution would likely be acceptable.

Preview: https://deploy-preview-633--nats-io.netlify.app/

### Screenshots

Before:

> <img src="https://user-images.githubusercontent.com/4140793/116103050-3aa5cf80-a67d-11eb-9115-7cb78d93b34b.png" width=300>


After:

> <img src="https://user-images.githubusercontent.com/4140793/116103199-5e691580-a67d-11eb-99d5-0186db0ea1c7.png" width=300>

These screenshots are generated from Safari 14.0.3.