### PR TITLE
fix invalid link on download latest button

### DIFF
--- a/layouts/partials/download/servers.html
+++ b/layouts/partials/download/servers.html
@@ -10,7 +10,7 @@
   {{ range $servers }}
   {{ $repo := printf "%s/%s" .org .repo }}
   {{ $url  := printf "https://github.com/%s" $repo }}
-  {{ $ghLatest  := printf "https://github.com/%s/%s/releases/latest" .org $repo }}
+  {{ $ghLatest  := printf "https://github.com/%s/releases/latest" $repo }}
   {{ $docker    := printf "https://hub.docker.com/_/%s" .docker }}
   {{ $prefix    := .prefix }}
   {{ $release   := .release }}


### PR DESCRIPTION
On the [download page](https://nats.io/download/), the **Download latest** button is pointing toward an invalid link.

![image](https://user-images.githubusercontent.com/982868/116795978-0316a780-ab03-11eb-9372-9f8ff1cd69a4.png)

The correct link should be:

```
https://github.com/nats-io/nats-server/releases/latest
```

This PR will resolve the particular issue.