### PR TITLE
NATS Go client v1.11.0

### DIFF
--- a/data/language.toml
+++ b/data/language.toml
@@ -153,8 +153,8 @@ supported = true
 jetstream_support = true
 author = "NATS Authors"
 link = "https://github.com/nats-io"
-release_version = "1.7.2"
-release_date = "2019-02-21"
+release_version = "1.11.0"
+release_date = "2021-05-03"
 [[language.go.orgs]]
 org = "nats-io"
 repo = "stan.go"

--- a/data/releases.yaml
+++ b/data/releases.yaml
@@ -86,9 +86,9 @@ Releases:
   author:
     - name:
       link:
-  version_num: 1.9.2
+  version_num: 1.11.0
   release_notes: |
-    Release v1.9.2 on March 30th, 2020.
+    Release v1.11.0 on May 3rd, 2021.
   github:
     - user: nats-io
       repo: nats.go


### PR DESCRIPTION
Not sure if still relevant. I updated releases.yaml but also
language.toml, although it does not appear that we display relase
version and release dates.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>