### PR TITLE
Add swifty-nats client

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -382,6 +382,15 @@
     release:
       version: '3.0.0-alpha.1'
       date: '2016-08-28'
+  - org: aus-der-Technik
+    repo: swifty-nats
+    supported: false
+    author:
+      name: aus der Technik
+      link: https://github.com/aus-der-Technik
+    release:
+      version: '2.0.0'
+      date: '2021-09-01'      
 - language: TypeScript
   clients:
   - org: nats-io

--- a/data/language.toml
+++ b/data/language.toml
@@ -449,7 +449,7 @@ link = "https://github.com/kakilangit"
 release_version = "3.0.0-alpha.1"
 release_date = "2016-08-28"
 
-[language.swift]
+[language.swift_5_4]
 name = "Swift"
 [[language.swift.orgs]]
 org = "aus-der-Technik"

--- a/data/language.toml
+++ b/data/language.toml
@@ -448,9 +448,6 @@ author = "Firman Maulana"
 link = "https://github.com/kakilangit"
 release_version = "3.0.0-alpha.1"
 release_date = "2016-08-28"
-
-[language.swift_5_4]
-name = "Swift"
 [[language.swift.orgs]]
 org = "aus-der-Technik"
 repo = "swifty-nats"

--- a/data/language.toml
+++ b/data/language.toml
@@ -449,6 +449,17 @@ link = "https://github.com/kakilangit"
 release_version = "3.0.0-alpha.1"
 release_date = "2016-08-28"
 
+[language.swift]
+name = "Swift"
+[[language.swift.orgs]]
+org = "aus-der-Technik"
+repo = "swifty-nats"
+supported = false
+author = "aus der Technik"
+link = "https://github.com/aus-der-Technik"
+release_version = "2.0.0"
+release_date = "2021-09-01"
+
 [language.tcl]
 name = "Tcl"
 [[language.tcl.orgs]]


### PR DESCRIPTION
This Swift library in version 2.0.0 works now with the latest Nats-Server and do very well with Swift 5.4 on Mac and on Linux. We solved all warnings and errors, added logging and will maintain and support it. 