### PR TITLE
add Qt client to language.toml

### DIFF
--- a/data/language.toml
+++ b/data/language.toml
@@ -385,6 +385,16 @@ author = "John Lockwood"
 link = "https://github.com/johnwlockwood"
 release_date = "2016-11-12"
 
+[language.qt]
+name = "C++/Qt/QML"
+[[language.qt.orgs]]
+org = "kazmirchuk"
+repo = "qtnats"
+supported = false
+jetstream_support = true
+author = "Petro Kazmirchuk"
+link = "https://github.com/kazmirchuk"
+
 [language.qt5]
 name = "Qt5 C++"
 [[language.qt5.orgs]]


### PR DESCRIPTION
Hello,
I've published a new C++/Qt/QML client for NATS, based on cnats
licensed under Apache 2.0 as usual
Best regards,
Petro