### PR TITLE
Add rust client

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -352,6 +352,13 @@
       date: '2019-06-09'
 - language: Rust
   clients:
+  - org: "nats-io"
+    repo: "nats.rs"
+    supported: true
+    author:
+      name: "NATS Authors"
+      link: "https://nats.io"
+    link: "https://github.com/nats-io"
   - org: davidmcneil
     repo: rants
     supported: false


### PR DESCRIPTION
The [Rust clients](https://nats.io/download/rust/) page, which is in the first page of search results for "nats rust", does not list the official Rust client.

Before:

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/46173/204467879-5687b38f-6476-4956-b7bd-c8b338c48e64.png">

After:

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/46173/204467916-1d45af49-f39a-481d-877b-b8139134dda4.png">
