### PR TITLE
Remove ctx from Consume example in JetStream API preview

### DIFF
--- a/content/blog/preview-release-new-jetstream-client-api.md
+++ b/content/blog/preview-release-new-jetstream-client-api.md
@@ -86,7 +86,7 @@ Here is an example:
 
 ```go
 consumer, err := stream.Consumer(ctx, “CONSUMER”)
-cons, _ := consumer.Consume(ctx, func(msg jetstream.Msg) {
+cons, _ := consumer.Consume(func(msg jetstream.Msg) {
     msg.Ack()
     fmt.Printf(“Received a JetStream message: %s\n”, string(msg.Data()))
 })


### PR DESCRIPTION
This PR fixes invalid example in JetStream API preview blog post