### PR TITLE
Update addons.toml to include RisingWave-NATS and NATS-RisingWave connectors

### DIFF
--- a/data/addons.toml
+++ b/data/addons.toml
@@ -494,7 +494,23 @@ support = "Community"
 author = "g41797"
 authorHome = "https://github.com/g41797"
 
+[addons.risingwave_nats]
+name = "NATS JetStream to RisingWave Connector"
+home = "https://docs.risingwave.com/docs/current/ingest-from-nats/"
+description = "A RisingWave built-in connector that allows RisingWave to receive messages from NATS JetStream. RisingWave is a distributed SQL streaming database that enables simple, efficient, and reliable processing of streaming data."
+support = "RisingWave Team"
+[[addons.risingwave_nats.authors]]
+author = "RisingWave Team"
+authorHome = "https://github.com/risingwavelabs/risingwave"
 
+[addons.nats_risingwave]
+name = "RisingWave to NATS Connector"
+home = "https://docs.risingwave.com/docs/current/sink-to-nats/"
+description = "A RisingWave built-in connector that allows RisingWave to send messages to NATS. RisingWave is a distributed SQL streaming database that enables simple, efficient, and reliable processing of streaming data."
+support = "RisingWave Team"
+[[addons.nats_risingwave.authors]]
+author = "RisingWave Team"
+authorHome = "https://github.com/risingwavelabs/risingwave"
 
 #[addons.xxx]
 #name = ""


### PR DESCRIPTION
Created two entries as the two connectors have different pages for describing the usages.
We tested the connectors and they are working well. For detailed how-to guides, please see these two pages:
https://docs.risingwave.com/docs/current/ingest-from-nats/
https://docs.risingwave.com/docs/current/sink-to-nats/

Let me know if you have any questions. For the context, our team (RisingWave team) are working with your team for partnerships. Thanks! 