### PR TITLE
CLOMonitor: Add Linux Foundation Trademarks footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,15 +38,6 @@
 
   </div>
 
-  <div class="columns">
-    <div class="column container has-text-centered">
-      <p class="has-text-weight-large">
-        The Linux Foundation has registered trademarks and uses trademarks.
-        For a list of trademarks of The Linux Foundation, please see <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage page</a>.
-      </p>
-    </div>
-  </div>
-
 </footer>
 <style>
   :target::before {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,13 +6,15 @@
 {{ $menu    := site.Menus.main }}
 
 <footer class="footer has-background-{{ $bgColor }} has-text-{{ $color }}">
-<div class="columns is-vcentered">
+<div class="columns">
   <div class="column">
-    {{ partial "social-buttons.html" (dict "align" "left") }}
-    <p class="has-text-weight-large">
-      Copyright &copy; NATS Authors {{ $year }}
-    </p>
-  </div>
+    <section class="section">
+      {{ partial "social-buttons.html" (dict "align" "left") }}
+      <p class="has-text-weight-large">
+        Copyright &copy; NATS Authors {{ $year }}
+      </p>
+    </section>
+  </div>  
   <div class="column">
 
     {{ partial "home/cncf.html" (dict "align" "right") }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,6 +38,15 @@
 
   </div>
 
+  <div class="columns">
+    <div class="column container has-text-centered">
+      <p class="has-text-weight-large">
+        The Linux Foundation has registered trademarks and uses trademarks.
+        For a list of trademarks of The Linux Foundation, please see <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage page</a>.
+      </p>
+    </div>
+  </div>
+
 </footer>
 <style>
   :target::before {

--- a/layouts/partials/home/cncf.html
+++ b/layouts/partials/home/cncf.html
@@ -7,7 +7,7 @@
     </p>
     
     <p class="has-text-weight-light">
-      The Linux Foundation has registered trademarks and uses trademarks.
+      The Linux Foundation has registered trademarks and uses trademarks.<br>
       For a list of trademarks of The Linux Foundation, please see <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage page</a>.
     </p>
   </div>

--- a/layouts/partials/home/cncf.html
+++ b/layouts/partials/home/cncf.html
@@ -3,7 +3,12 @@
   <div class="container has-text-right">
     <img class="is-cncf-logo" src="{{ $img }}" alt="CNCF logo">
     <p class="is-size-5 is-size-5-mobile has-text-weight-light">
-    NATS is a <a href="https://cncf.io">Cloud Native Computing Foundation</a> incubating project
+      NATS is a <a href="https://cncf.io">Cloud Native Computing Foundation</a> incubating project
+    </p>
+    
+    <p class="has-text-weight-light">
+      The Linux Foundation has registered trademarks and uses trademarks.
+      For a list of trademarks of The Linux Foundation, please see <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage page</a>.
     </p>
   </div>
 </section>


### PR DESCRIPTION
I've seen an effort (https://github.com/nats-io/nats-server/pull/4923) by @philpennock to improve the CNCF CLOMonitor rating for NATS.

The rating shows here https://landscape.cncf.io/?selected=nats and is an indicator of the project following the best practices according to CNCF.

This should help passing the "Legal" CNCF CLOMonitor check: https://clomonitor.io/projects/cncf/nats#nats-server_legal by adding the LF trademarks footer to the website.
