### PR TITLE
Added Rabbit-going-NATS to the Connectors and Utilities list.

### DIFF
--- a/data/addons.toml
+++ b/data/addons.toml
@@ -221,6 +221,16 @@ author = "Lovoo"
 authorHome = "http://lovoo.com/"
 
 
+[addons.rabbit_going_nats]
+name = "Rabbit-going-NATS"
+home = "https://github.com/ideaconnect/rabbit-going-nats"
+description = "Tool which allows to passthrough messages fetched from RabbitMQ's queue to NATS PubSub. Useful if you receive a data feed through RabbitMQ, but you need to redistribute it further to multiple clients."
+support = "Community"
+[[addons.rabbit_going_nats.authors]]
+author = "IDCT Bartosz Pachołek"
+authorHome = "https://idct.tech/"
+
+
 [addons.rancher_nats]
 name = "Rancher NATS"
 home = "http://bit.ly/1X36qKZ"


### PR DESCRIPTION
Added information about and link to Rabbit-going-NATS tool which allows passing messages from RabbitMQ to NATS. It is a project in C# which can be compiled to .NET CLR and to native Linux AMD64 and ARM64 binaries. Basic functionality testing is provided.

Allows to resolve a solution as in the sample graph:

![image](https://github.com/user-attachments/assets/87e73540-af64-4036-aae0-e64d3638b539)

README:
https://github.com/ideaconnect/rabbit-going-nats/blob/main/README.md

LICENSE: Apache License 2.0

Article which further explains a usecase:
https://idct.tech/software/rabbit-going-nats
