### PR TITLE
Update logo animations

### DIFF
--- a/layouts/partials/home/users.html
+++ b/layouts/partials/home/users.html
@@ -156,6 +156,26 @@
     }
   }
 
+  /* Reserve space for the logo grid while logos are hidden/loading,
+     preventing cumulative layout shift. Heights match 1–3 rows of
+     120px logo boxes at each breakpoint. */
+  #companies-grid {
+    min-height: 360px; /* mobile: 2-col grid, up to 3 rows */
+    transition: opacity 0.3s ease;
+  }
+
+  @media (min-width: 769px) {
+    #companies-grid { min-height: 240px; } /* tablet: 3-col, ~2 rows */
+  }
+
+  @media (min-width: 1216px) {
+    #companies-grid { min-height: 120px; } /* widescreen: 5-col, 1 row */
+  }
+
+  #companies-grid.fading {
+    opacity: 0;
+  }
+
   /* Logo scaling for visual balance */
 
   /* Scale up compact logos */
@@ -242,7 +262,7 @@
           is-one-third-tablet
           is-one-quarter-desktop
           is-one-fifth-widescreen
-          logo company-logo{{ if $isHidden }} hidden-logo{{ end }}" data-industry="{{ $industry }}" {{ if $isHidden }}style="display: none;"{{ end }}>
+          logo company-logo{{ if $isHidden }} hidden-logo{{ end }}" data-industry="{{ $industry }}" style="display: none;">
 <a href="{{ .home }}" target="_blank">
   <img class="is-user-logo" src="{{ $img }}" alt="{{ .name }} logo">
 </a>
@@ -267,8 +287,8 @@
 </section>
 
 <script>
-// Auto-rotate state (global so toggleLogos can access it)
 let autoRotateInterval = null;
+let currentIndustry = 'ai';
 
 function stopAutoRotate() {
   if (autoRotateInterval) {
@@ -277,34 +297,69 @@ function stopAutoRotate() {
   }
 }
 
-function toggleLogos() {
-  stopAutoRotate(); // Stop auto-rotate when user expands logos
+function applyFilter(industry) {
+  const logos = document.querySelectorAll('.company-logo');
+  const isMobile = window.innerWidth <= 768;
+  const shouldLimit = isMobile || industry === 'tech';
+  let visibleCount = 0;
 
-  const hiddenLogos = document.querySelectorAll('.hidden-logo');
-  const button = document.getElementById('toggle-logos-btn');
-  const isExpanded = button.getAttribute('data-expanded') === 'true';
+  logos.forEach(logo => {
+    logo.classList.remove('mobile-visible', 'mobile-hidden', 'mobile-last');
 
-  hiddenLogos.forEach(logo => {
-    if (isExpanded) {
-      logo.style.display = 'none';
+    if (logo.getAttribute('data-industry') === industry) {
+      if (shouldLimit) {
+        if (visibleCount < 5) {
+          logo.style.display = '';
+          logo.classList.add('mobile-visible');
+          visibleCount++;
+          if (visibleCount === 5) logo.classList.add('mobile-last');
+        } else {
+          logo.style.display = 'none';
+          logo.classList.add('mobile-hidden');
+        }
+      } else {
+        logo.style.display = '';
+      }
     } else {
-      logo.style.display = '';
+      logo.style.display = 'none';
     }
   });
+}
 
-  if (isExpanded) {
-    button.textContent = 'Show All Companies';
-    button.setAttribute('data-expanded', 'false');
-  } else {
-    button.textContent = 'Show Less';
-    button.setAttribute('data-expanded', 'true');
-  }
+function toggleLogos() {
+  stopAutoRotate();
+
+  const button = document.getElementById('toggle-logos-btn');
+  const isExpanded = button.getAttribute('data-expanded') === 'true';
+  const allTabs = document.querySelectorAll('.industry-tab');
+  const grid = document.getElementById('companies-grid');
+
+  grid.classList.add('fading');
+  setTimeout(() => {
+    if (isExpanded) {
+      // Collapsing: restore filtered industry view and re-highlight the active tab
+      button.textContent = 'Show All Companies';
+      button.setAttribute('data-expanded', 'false');
+      applyFilter(currentIndustry);
+      allTabs.forEach(t => {
+        t.classList.toggle('active', t.getAttribute('data-industry') === currentIndustry);
+      });
+    } else {
+      // Expanding: show every logo and remove the active tab highlight
+      document.querySelectorAll('.company-logo').forEach(logo => {
+        logo.style.display = '';
+      });
+      button.textContent = 'Show Less';
+      button.setAttribute('data-expanded', 'true');
+      allTabs.forEach(t => t.classList.remove('active'));
+    }
+    requestAnimationFrame(() => grid.classList.remove('fading'));
+  }, 300);
 }
 
 // Industry filter functionality
 document.addEventListener('DOMContentLoaded', function() {
   const tabs = document.querySelectorAll('.industry-tab');
-  const logos = document.querySelectorAll('.company-logo');
   const filtersContainer = document.getElementById('industry-filters');
   const filtersWrapper = document.querySelector('.industry-filters-wrapper');
   const scrollDots = document.querySelectorAll('.scroll-dot');
@@ -367,8 +422,11 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('resize', updateScrollIndicators);
   }
 
+  const grid = document.getElementById('companies-grid');
+  let fadeTimeout = null;
+
   function filterByIndustry(industry, clickedTab) {
-    // Update tab active class
+    // Update tab active class immediately
     tabs.forEach(t => {
       t.classList.toggle('active', t.getAttribute('data-industry') === industry);
     });
@@ -380,41 +438,25 @@ document.addEventListener('DOMContentLoaded', function() {
       toggleBtn.setAttribute('data-expanded', 'false');
     }
 
-    const isMobile = window.innerWidth <= 768;
-    // Limit to 5 logos on mobile for all categories, and on desktop for tech
-    const shouldLimit = isMobile || industry === 'tech';
-    let visibleCount = 0;
+    // Cancel any in-flight fade before starting a new one
+    if (fadeTimeout) {
+      clearTimeout(fadeTimeout);
+      fadeTimeout = null;
+    }
 
-    // Filter logos
-    logos.forEach(logo => {
-      // Reset mobile classes
-      logo.classList.remove('mobile-visible', 'mobile-hidden', 'mobile-last');
-
-      if (logo.getAttribute('data-industry') === industry) {
-        // Limit to 5 logos when applicable
-        if (shouldLimit) {
-          if (visibleCount < 5) {
-            logo.style.display = '';
-            logo.classList.add('mobile-visible');
-            visibleCount++;
-            // Mark the 5th logo as last for centering
-            if (visibleCount === 5) {
-              logo.classList.add('mobile-last');
-            }
-          } else {
-            logo.style.display = 'none';
-            logo.classList.add('mobile-hidden');
-          }
-        } else {
-          logo.style.display = '';
-        }
-      } else {
-        logo.style.display = 'none';
-      }
-    });
+    // Fade out → swap → fade in
+    grid.classList.add('fading');
+    fadeTimeout = setTimeout(() => {
+      applyFilter(industry);
+      // rAF ensures the DOM update is painted before we remove the class,
+      // so the browser actually runs the fade-in transition
+      requestAnimationFrame(() => {
+        grid.classList.remove('fading');
+      });
+    }, 300);
 
     // Scroll clicked tab into view on mobile
-    if (clickedTab && filtersContainer && isMobile) {
+    if (clickedTab && filtersContainer && window.innerWidth <= 768) {
       const containerRect = filtersContainer.getBoundingClientRect();
       const tabRect = clickedTab.getBoundingClientRect();
       const scrollOffset = tabRect.left - containerRect.left - (containerRect.width / 2) + (tabRect.width / 2);
@@ -422,8 +464,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  // Track current industry for resize handler
-  let currentIndustry = 'ai';
   const industries = ['ai', 'automotive', 'energy', 'financial', 'tech', 'telecom', 'retail'];
   let currentIndex = 0;
 

--- a/layouts/partials/home/users.html
+++ b/layouts/partials/home/users.html
@@ -161,6 +161,7 @@
      120px logo boxes at each breakpoint. */
   #companies-grid {
     min-height: 360px; /* mobile: 2-col grid, up to 3 rows */
+    justify-content: center;
     transition: opacity 0.3s ease;
   }
 


### PR DESCRIPTION
Adds smooth fade animations and fixes to the "Powering Industry Leaders" companies grid on the homepage.                                                                 
 
### Changes     

  - **Fade transition on industry filter**: The companies grid now fades out (300ms),   
  swaps logos, then fades back in when switching between industry tabs — both on manual
  click and auto-rotate. Uses `requestAnimationFrame` to ensure the fade-in transition  
  actually fires after the DOM update.
  - **Fade transition on Show All / Show Less**: Applied the same fade logic to the
  "Show All Companies" button toggle.                                                   
  - **Tab highlight state on Show All**: Clicking "Show All Companies" now removes the
  active highlight from all industry tabs (since no filter is active). Clicking "Show   
  Less" restores the highlight to the previously selected industry.
  - **Fix initial load flash**: All company logos now start hidden via                  
  `style="display:none"` in the template. Previously, all rank < 25 logos were visible  
  until `DOMContentLoaded` fired and applied the AI filter, causing a flash of all
  logos.                                                                                
  - **Prevent cumulative layout shift (CLS)**: Added `min-height` to `#companies-grid`
  sized to the expected populated grid height at each breakpoint (360px mobile → 240px  
  tablet → 120px widescreen), so the page doesn't shift when logos load in.
  - **Dead code removal**: Removed an unused `logos` variable from the                  
  `DOMContentLoaded` closure after `applyFilter` was lifted to global scope. 