### PR TITLE
update logo sizing per Andrew fix

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -252,13 +252,17 @@ $colors: mergeColorMaps(("primary-dark": ($nats-dark-blue, $white), "light-green
   justify-content: center
   height: 120px      /* same visual "box" for all logos */
 
+  > a
+    display: block
+    width: 100%
+
 /* Make logos uniform size */
-.is-user-logo 
-  max-height: 45px   /* adjust as needed */
+.is-user-logo
+  max-height: 45px
   max-width: 100%
   object-fit: contain
   display: block
-  margin: 2 auto    /* centers logo */
+  margin: 0 auto
 
   // fallback for SVGs without intrinsic size
   &[src$=".svg"]

--- a/layouts/partials/home/users.html
+++ b/layouts/partials/home/users.html
@@ -177,46 +177,6 @@
     opacity: 0;
   }
 
-  /* Logo scaling for visual balance */
-
-  /* Scale up compact logos */
-  img[src*="nvidia"], img[src*="capitalone"] {
-    transform: scale(1.4);
-  }
-  img[src*="replit"] {
-    transform: scale(1.0);
-  }
-  img[src*="activision"] {
-    transform: scale(3.0);
-  }
-  img[src*="tinder"] {
-    transform: scale(1.5);
-  }
-
-  /* Scale down wide logos */
-  img[src*="paloalto"], img[src*="inference"], img[src*="siemens"], img[src*="schaeffler"], img[src*="form3"] {
-    transform: scale(0.85);
-  }
-
-  /* Automotive & Industrial - scale down wide logos */
-  img[src*="rivian"], img[src*="machinemetrics"], img[src*="volvo"], img[src*="wirelesscar"] {
-    transform: scale(0.8);
-  }
-
-  /* Energy */
-  img[src*="eviny"] {
-    transform: scale(1.5);
-  }
-
-  /* Telecom */
-  img[src*="att"] {
-    transform: scale(1.4);
-  }
-
-  /* Tech & Cloud */
-  img[src*="vmware"], img[src*="netlify"], img[src*="gitlab"] {
-    transform: scale(1.4);
-  }
 </style>
 
 <section class="section has-background-white">


### PR DESCRIPTION
This PR fixes the sizing of logos on the homepage. Before:

<img width="3594" height="1970" alt="image" src="https://github.com/user-attachments/assets/5163e4ae-9cb2-495f-b2ba-194acb584bbb" />
 
(see mattilsynet)

After:
<img width="885" height="688" alt="image" src="https://github.com/user-attachments/assets/63617ffb-d639-4658-858b-d3f2859a32ea" />
