### PR TITLE
add robots.txt

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://nats.io/"
 languageCode = "en-us"
 defaultLanguage = "en"
 title = "NATS.io"
+enableRobotsTXT = true
 
 pygmentsCodeFences = "true"
 pygmentsUseClasses = "true"

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,52 @@
+User-agent: *
+Allow: /
+
+# AI content usage preferences (Content Signals)
+# https://contentsignals.org/
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+# OpenAI crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+# Anthropic crawlers
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+# Google AI crawler
+User-agent: Google-Extended
+Allow: /
+
+# Perplexity crawler
+User-agent: PerplexityBot
+Allow: /
+
+# Amazon crawler
+User-agent: Amazonbot
+Allow: /
+
+# Meta crawler
+User-agent: FacebookBot
+Allow: /
+
+# Apple crawler
+User-agent: Applebot-Extended
+Allow: /
+
+# Disallow pure training scrapers
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
 Adds a Hugo-generated `robots.txt` to nats.io, modeled on synadia.com's policy.

  - `config.toml`: `enableRobotsTXT = true`
  - `layouts/robots.txt`: allows major AI search bots (GPTBot, ClaudeBot, PerplexityBot, etc.), disallows pure training scrapers (CCBot, Bytespider), declares
  Content Signals
  - Sitemap URL auto-derives from `baseURL` → `https://nats.io/sitemap.xml`

Note: this won't fix the GSC "403" alert on its own — a missing robots.txt returns 404, not 403. The actual 403 source is likely a Netlify account setting or upstream CDN/WAF and needs separate investigation.

  ## Test plan

  - [ ] `curl -i https://nats.io/robots.txt` returns 200 with expected body after deploy