### PR TITLE
[language] Add claxon as a Pure Clojure client

### DIFF
--- a/data/language.toml
+++ b/data/language.toml
@@ -71,6 +71,18 @@ author = "Employee Republic"
 link = "https://github.com/employeerepublic/"
 release_date = "2017-05-11"
 
+[language.pure_clojure]
+name = "Pure Clojure"
+[[language.pure_clojure.orgs]]
+org = "lispyclouds"
+repo = "claxon"
+supported = false
+jetstream_support = true
+author = "Rahul De"
+link = "https://github.com/lispyclouds"
+release_date = "2026-07-02"
+release_version = "1.1"
+
 [language.net]
 name = ".NET"
 [[language.net.orgs]]


### PR DESCRIPTION
This is the more maintained, pure clojure client supporting all of the current NATS features in flexible manner.