### PR TITLE
Add Easy NATS to the addon list

### DIFF
--- a/data/addons.toml
+++ b/data/addons.toml
@@ -659,6 +659,15 @@ support = "Community"
 author = "John Hooks"
 authorHome = "https://gitlab.com/sencillodev"
 
+[addons.easy_nats]
+name = "Easy NATS"
+home = "https://easy-nats.sworld.club/"
+description = "A fast Rust NATS GUI with powerful search and a dockable workspace."
+support = "Community"
+[[addons.easy_nats.authors]]
+author = "Sworld"
+authorHome = "https://github.com/mcthesw"
+
 #[addons.xxx]
 #name = ""
 #home = ""


### PR DESCRIPTION
I've added the link to the GUI client I made

<img width="2390" height="1431" alt="image" src="https://github.com/user-attachments/assets/eaef9da7-be2e-49eb-add3-e450891326df" />
