### PR TITLE
Add IDCT PHP NATS JetStream client

### DIFF
--- a/data/language.toml
+++ b/data/language.toml
@@ -310,6 +310,15 @@ link = "https://github.com/repejota"
 release_version = "0.8.6"
 release_date = "2017-07-17"
 [[language.php.orgs]]
+org = "ideaconnect"
+repo = "php-nats-jetstream-client"
+supported = false
+jetstream_support = true
+author = "IDCT Bartosz Pachołek"
+link = "https://github.com/ideaconnect"
+release_version = "2.8.0"
+release_date = "2026-08-08"
+[[language.php.orgs]]
 org = "byrnedo"
 repo = "php-nats-streaming"
 supported = false

--- a/layouts/shortcodes/streaming_client_glc.html
+++ b/layouts/shortcodes/streaming_client_glc.html
@@ -3,10 +3,14 @@
 {{ $streaming := (slice) }} {{/* Assemble a list of streaming clients */}}
 {{ range $languages }}
 {{ $this := . }}
+{{ $hasJetstream := false }}
 {{ range .orgs }}
 {{ if .jetstream_support }}
-{{ $streaming = $streaming | append $this }}
+{{ $hasJetstream = true }}
 {{ end }}
+{{ end }}
+{{ if $hasJetstream }}
+{{ $streaming = $streaming | append $this }}
 {{ end }}
 {{ end }}
 
@@ -37,11 +41,7 @@
   {{ range $k, $v := $streaming }}
     <tr>
     <td>
-    {{ range $k, $a := $v.orgs }}
-      {{ if $a.jetstream_support }}
       {{ $v.name }}
-      {{ end }}
-      {{ end }}
     </td>
     <!--<td>
       {{ $n := len $v.orgs }}


### PR DESCRIPTION
Two changes:
1) Adds idct/php-nats-jetstream-client as a third PHP client in data/language.toml.

2) PHP is the first language with two entries marked jetstream_support = true. streaming_client_glc.html appended the language to $streaming once per matching org, and reprinted the language name once per matching org in the Language cell, so the new entry alone rendered a duplicated PHP row reading "PHP PHP" in the JetStream table. The shortcode now sets a flag and appends the language once. Written without break, which is not available in the pinned Hugo 0.80.0.

Before / after the change screenshots:
<img width="2400" height="2305" alt="03-before-after-comparison" src="https://github.com/user-attachments/assets/19d3e28e-2105-425f-b29c-09ff7d91d375" />
